### PR TITLE
feat: Display list of protected domains

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,16 @@
         height: 100vh;
         width: 100vw;
         color: white;
-        overflow: hidden;
+        overflow: auto;
         text-align: center;
         background-color: black;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
         position: relative;
+        padding-top: 5rem;
+        padding-bottom: 5rem;
       }
 
       body::after {
@@ -74,6 +77,40 @@
         right: 1%;
         filter: invert(1);
       }
+
+      #domain-list-container {
+        margin-top: 2rem;
+        max-height: 50vh;
+        overflow-y: auto;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 0.5rem;
+        padding: 1rem;
+        width: 80%;
+        max-width: 600px;
+      }
+
+      #domain-list {
+        list-style: none;
+        padding: 0;
+        margin-top: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      #domain-list a {
+        color: white;
+        text-decoration: none;
+        margin: 0.25rem;
+        padding: 0.25rem 0.5rem;
+        border-radius: 0.25rem;
+        background-color: rgba(255, 255, 255, 0.1);
+        transition: background-color 0.2s ease;
+      }
+
+      #domain-list a:hover {
+        background-color: rgba(255, 255, 255, 0.2);
+      }
     </style>
   </head>
   <body>
@@ -81,6 +118,12 @@
       <span class="domain">example.pages.dev</span> <br />
       is acquired to prevent misuse
     </div>
+
+    <div id="domain-list-container" style="display: none;">
+      <h2>Protected Domains</h2>
+      <div id="domain-list"></div>
+    </div>
+
     <img src="woka.png" alt="WOOKA" height="25px" />
     <script>
       const domain = document.querySelector('.domain');
@@ -88,6 +131,41 @@
       const source = url.searchParams.get("source");
 
       domain.textContent = source || "The domain you are looking for";
+
+      const domainListContainer = document.getElementById('domain-list-container');
+      const domainList = document.getElementById('domain-list');
+
+      fetch('README.md')
+        .then(response => {
+          if (!response.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return response.text();
+        })
+        .then(text => {
+          const domains = (text.match(/- \[(.*?)\]\(https:/g) || []).map(line => {
+            const match = line.match(/- \[(.*?)\]/);
+            return match ? match[1] : null;
+          }).filter(Boolean);
+
+          if (domains.length > 0) {
+            domainList.innerHTML = ''; // Clear existing content
+            domains.forEach(domainName => {
+              const link = document.createElement('a');
+              link.href = `https://${domainName}`;
+              link.textContent = domainName;
+              link.target = '_blank';
+              link.rel = 'noopener noreferrer';
+              domainList.appendChild(link);
+            });
+            domainListContainer.style.display = 'block';
+          }
+        })
+        .catch(error => {
+          console.error('There has been a problem with your fetch operation:', error);
+          domainListContainer.style.display = 'block';
+          domainList.innerHTML = '<p>Could not load domain list.</p>';
+        });
     </script>
   </body>
 </html>


### PR DESCRIPTION
This feature enhances the landing page by displaying the full list of domains that are being protected.

The changes include:
- Modifying `index.html` to add a new section for the domain list.
- Adding JavaScript to fetch the `README.md` file, parse it for domain names, and dynamically populate the list on the page.
- Styling the new list to be consistent with the existing design.
- The list is fetched and rendered client-side, so it will automatically update if the `README.md` file is changed.